### PR TITLE
Added net names to schematic

### DIFF
--- a/PCB/lixie_digit.brd
+++ b/PCB/lixie_digit.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.6.0">
+<eagle version="7.7.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -11230,9 +11230,8 @@ design rules under a new name.</description>
 <element name="JP2" library="adafruit" package="1X03" value="" x="2" y="18" smashed="yes" rot="R90">
 <attribute name="VALUE" x="5.175" y="14.19" size="1.27" layer="27" rot="R90"/>
 </element>
-<element name="C1" library="adafruit" package="E3,5-8" value="" x="5" y="5" smashed="yes">
-<attribute name="NAME" x="9.302" y="1.794" size="1.27" layer="25" font="vector" ratio="10"/>
-<attribute name="VALUE" x="2.714" y="1.952" size="1.27" layer="27" ratio="10"/>
+<element name="C1" library="adafruit" package="E3,5-8" value="1000 µF" x="5" y="5" smashed="yes">
+<attribute name="VALUE" x="5.214" y="2.952" size="1.016" layer="27" ratio="10" align="center"/>
 </element>
 </elements>
 <signals>
@@ -11380,7 +11379,7 @@ design rules under a new name.</description>
 <wire x1="11.95" y1="14.35" x2="14.35" y2="16.75" width="0.6096" layer="1"/>
 <wire x1="14.35" y1="16.75" x2="14.65" y2="16.75" width="0.6096" layer="1"/>
 </signal>
-<signal name="N$20">
+<signal name="+5V">
 <contactref element="LED1" pad="1-VDD"/>
 <contactref element="LED2" pad="1-VDD"/>
 <contactref element="LED3" pad="1-VDD"/>
@@ -11531,13 +11530,13 @@ design rules under a new name.</description>
 <via x="14" y="1.5" extent="1-16" drill="0.6"/>
 <via x="48.5" y="1.5" extent="1-16" drill="0.6"/>
 </signal>
-<signal name="N$23">
+<signal name="DIN">
 <contactref element="LED1" pad="4-DIN"/>
 <contactref element="JP1" pad="1"/>
 <wire x1="60.5" y1="20.54" x2="57.64" y2="20.54" width="0.6096" layer="1"/>
 <wire x1="57.64" y1="20.54" x2="53.95" y2="16.85" width="0.6096" layer="1"/>
 </signal>
-<signal name="N$24">
+<signal name="DOUT">
 <contactref element="JP2" pad="3"/>
 <contactref element="LED20" pad="2-DOUT"/>
 <wire x1="2" y1="20.54" x2="3" y2="19.5" width="0.6096" layer="1"/>

--- a/PCB/lixie_digit.sch
+++ b/PCB/lixie_digit.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.6.0">
+<eagle version="7.7.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -5794,7 +5794,7 @@ diameter 5 mm, grid 2.54 mm</description>
 <part name="LED20" library="adafruit" deviceset="WS2812B" device="5050"/>
 <part name="JP1" library="adafruit" deviceset="PINHD-1X3" device=""/>
 <part name="JP2" library="adafruit" deviceset="PINHD-1X3" device=""/>
-<part name="C1" library="adafruit" deviceset="CPOL-US" device="E3.5-8"/>
+<part name="C1" library="adafruit" deviceset="CPOL-US" device="E3.5-8" value="1000 µF"/>
 </parts>
 <sheets>
 <sheet>
@@ -5821,8 +5821,8 @@ diameter 5 mm, grid 2.54 mm</description>
 <instance part="LED18" gate="G$1" x="449.58" y="15.24"/>
 <instance part="LED19" gate="G$1" x="474.98" y="15.24"/>
 <instance part="LED20" gate="G$1" x="500.38" y="15.24"/>
-<instance part="JP1" gate="A" x="-25.4" y="17.78" rot="R180"/>
-<instance part="JP2" gate="A" x="533.4" y="17.78"/>
+<instance part="JP1" gate="A" x="-30.48" y="17.78" rot="R180"/>
+<instance part="JP2" gate="A" x="543.56" y="17.78"/>
 <instance part="C1" gate="G$1" x="-5.08" y="22.86"/>
 </instances>
 <busses>
@@ -5942,7 +5942,7 @@ diameter 5 mm, grid 2.54 mm</description>
 <pinref part="LED20" gate="G$1" pin="DI"/>
 </segment>
 </net>
-<net name="N$20" class="0">
+<net name="+5V" class="0">
 <segment>
 <pinref part="LED1" gate="G$1" pin="VDD"/>
 <pinref part="LED2" gate="G$1" pin="VDD"/>
@@ -6000,7 +6000,7 @@ diameter 5 mm, grid 2.54 mm</description>
 <junction x="454.66" y="30.48"/>
 <pinref part="LED20" gate="G$1" pin="VDD"/>
 <junction x="480.06" y="30.48"/>
-<wire x1="-22.86" y1="20.32" x2="-12.7" y2="20.32" width="0.1524" layer="91"/>
+<wire x1="-27.94" y1="20.32" x2="-12.7" y2="20.32" width="0.1524" layer="91"/>
 <wire x1="-12.7" y1="20.32" x2="-12.7" y2="30.48" width="0.1524" layer="91"/>
 <wire x1="-12.7" y1="30.48" x2="-5.08" y2="30.48" width="0.1524" layer="91"/>
 <junction x="22.86" y="30.48"/>
@@ -6011,10 +6011,12 @@ diameter 5 mm, grid 2.54 mm</description>
 <wire x1="520.7" y1="30.48" x2="520.7" y2="20.32" width="0.1524" layer="91"/>
 <junction x="505.46" y="30.48"/>
 <pinref part="JP2" gate="A" pin="1"/>
-<wire x1="520.7" y1="20.32" x2="530.86" y2="20.32" width="0.1524" layer="91"/>
+<wire x1="520.7" y1="20.32" x2="541.02" y2="20.32" width="0.1524" layer="91"/>
 <pinref part="C1" gate="G$1" pin="+"/>
 <wire x1="-5.08" y1="25.4" x2="-5.08" y2="30.48" width="0.1524" layer="91"/>
 <junction x="-5.08" y="30.48"/>
+<label x="-22.86" y="20.32" size="1.778" layer="95"/>
+<label x="528.32" y="20.32" size="1.778" layer="95"/>
 </segment>
 </net>
 <net name="GND" class="0">
@@ -6076,38 +6078,42 @@ diameter 5 mm, grid 2.54 mm</description>
 <pinref part="LED20" gate="G$1" pin="GND"/>
 <wire x1="474.98" y1="5.08" x2="500.38" y2="5.08" width="0.1524" layer="91"/>
 <junction x="474.98" y="5.08"/>
-<wire x1="-22.86" y1="17.78" x2="-12.7" y2="17.78" width="0.1524" layer="91"/>
+<wire x1="-27.94" y1="17.78" x2="-12.7" y2="17.78" width="0.1524" layer="91"/>
 <wire x1="-12.7" y1="17.78" x2="-12.7" y2="5.08" width="0.1524" layer="91"/>
 <wire x1="-12.7" y1="5.08" x2="-5.08" y2="5.08" width="0.1524" layer="91"/>
 <junction x="17.78" y="5.08"/>
 <pinref part="JP1" gate="A" pin="2"/>
 <pinref part="JP2" gate="A" pin="2"/>
 <wire x1="-5.08" y1="5.08" x2="17.78" y2="5.08" width="0.1524" layer="91"/>
-<wire x1="530.86" y1="17.78" x2="520.7" y2="17.78" width="0.1524" layer="91"/>
+<wire x1="541.02" y1="17.78" x2="520.7" y2="17.78" width="0.1524" layer="91"/>
 <wire x1="520.7" y1="17.78" x2="520.7" y2="5.08" width="0.1524" layer="91"/>
 <wire x1="520.7" y1="5.08" x2="500.38" y2="5.08" width="0.1524" layer="91"/>
 <junction x="500.38" y="5.08"/>
 <pinref part="C1" gate="G$1" pin="-"/>
 <wire x1="-5.08" y1="5.08" x2="-5.08" y2="17.78" width="0.1524" layer="91"/>
 <junction x="-5.08" y="5.08"/>
+<label x="-22.86" y="17.78" size="1.778" layer="95"/>
+<label x="528.32" y="17.78" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$23" class="0">
+<net name="DIN" class="0">
 <segment>
-<wire x1="-22.86" y1="15.24" x2="-15.24" y2="15.24" width="0.1524" layer="91"/>
+<wire x1="-27.94" y1="15.24" x2="-15.24" y2="15.24" width="0.1524" layer="91"/>
 <pinref part="LED1" gate="G$1" pin="DI"/>
 <wire x1="-15.24" y1="15.24" x2="-15.24" y2="12.7" width="0.1524" layer="91"/>
 <wire x1="-15.24" y1="12.7" x2="5.08" y2="12.7" width="0.1524" layer="91"/>
 <pinref part="JP1" gate="A" pin="1"/>
+<label x="-22.86" y="15.24" size="1.778" layer="95"/>
 </segment>
 </net>
-<net name="N$24" class="0">
+<net name="DOUT" class="0">
 <segment>
 <pinref part="JP2" gate="A" pin="3"/>
-<wire x1="530.86" y1="15.24" x2="523.24" y2="15.24" width="0.1524" layer="91"/>
+<wire x1="541.02" y1="15.24" x2="523.24" y2="15.24" width="0.1524" layer="91"/>
 <pinref part="LED20" gate="G$1" pin="DO"/>
 <wire x1="523.24" y1="15.24" x2="523.24" y2="12.7" width="0.1524" layer="91"/>
 <wire x1="523.24" y1="12.7" x2="513.08" y2="12.7" width="0.1524" layer="91"/>
+<label x="528.32" y="15.24" size="1.778" layer="95"/>
 </segment>
 </net>
 </nets>


### PR DESCRIPTION
Small quality-of-life update, but I changed the net names in the schematic to be descriptive (e.g. from "N$20" to "+5V") and added labels.

I also added the 1000 µF value to the capacitor and put that in place of the 'C1' annotation on the top silkscreen.